### PR TITLE
hostapd: fix iapp_interface option

### DIFF
--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -372,7 +372,7 @@ hostapd_set_bss_options() {
 	[ -n "$network_bridge" ] && append bss_conf "bridge=$network_bridge" "$N"
 	[ -n "$iapp_interface" ] && {
 		local ifname
-		network_get_device ifname "$iapp_interface" || ifname = "$iapp_interface"
+		network_get_device ifname "$iapp_interface" || ifname="$iapp_interface"
 		append bss_conf "iapp_interface=$ifname" "$N"
 	}
 


### PR DESCRIPTION
ifname variable were not assigned due to syntax error
causing the hostapd config file to have an empty iapp_interface= option

Signed-off-by: Lorenzo Santina <lorenzo.santina.dev@gmail.com>
